### PR TITLE
use memcpy to copy memory

### DIFF
--- a/src/chip8.c
+++ b/src/chip8.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #define debug_print(fmt, ...)                         \
@@ -127,9 +128,7 @@ void init_cpu(void) {
     srand((unsigned int)time(NULL));
 
     // load fonts into memory
-    for (int i = 0; i < 80; i++) {
-        memory[i] = fontset[i];
-    }
+    memcpy(memory, fontset, sizeof(fontset));
 }
 
 /**


### PR DESCRIPTION
Hi, I'm a beginner C programmer myself and I'm sending a minor patch to test the waters. 

It's a bit silly to use a for loop to copy memory when we have memcpy. This patch also gets rid of the magic number 80, the sizeof operator is the right tool for this job.