### PR TITLE
overhaul Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-LDFLAGS=-lm -lSDL2 -L/usr/local/lib
+.POSIX:
+MYCFLAGS  = -I/usr/local/include -Wall -Wextra -pedantic -std=c99 $(CFLAGS)
+MYLDFLAGS = -L/usr/local/lib $(LDFLAGS)
+MYLDLIBS  = -lm -lSDL2 $(LDLIBS)
 
-all:
-	mkdir bin
-	$(CC) ./src/main.c ./src/chip8.c ./src/peripherals.c -o ./bin/emulator.out -Wall -Wextra -pedantic -std=c99 $(LDFLAGS)
+sources = src/main.c src/chip8.c src/peripherals.c
+headers = src/inc/chip8.h src/inc/peripherals.h
+
+all: bin/emulator.out
+
+bin/emulator.out: $(sources) $(headers)
+	@mkdir -p bin
+	$(CC) $(MYCFLAGS) $(MYLDFLAGS) -o $@ $(sources) $(MYLDLIBS)
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
Hi again.
Someone in the thread at https://www.reddit.com/r/C_Programming/comments/lcgwj3/a_simple_and_beginner_friendly_chip8_emulator/ provided an overhauled Makefile.

I made a few small changes to their suggestion:
- The .POSIX special target was added, now the makefile is explicitly POSIX-compliant.
- CFLAGS, LDFLAGS, and LDLIBS are appended to MYCFLAGS, MYLDFLAGS, and MYLDLIBS respectively, these variables are then used by the C compiler. This allows appending extra compiler flags in pure POSIX make, no GNU extensions.
- /usr/local/include is added to the list of paths to search for includes. /usr/local/lib is searched for libraries, so I thought this would match the original intent. This change also fixes the build on OpenBSD.

Now making debug or optimized builds is easy:
$ make CFLAGS='-g'
Would build this program with debug symbols without touching the source code for instance.