### PR TITLE
Fixed 0xFX55 implementation

### DIFF
--- a/src/chip8.c
+++ b/src/chip8.c
@@ -599,7 +599,7 @@ void emulate_cycle(void) {
                     debug_print("[OK] 0x%X: FX55\n", op);
 
                     for (int i = 0; i <= x; i++) {
-                        V[i] = memory[I + i];
+                        memory[I + i] = V[i];
                     }
 
                     pc += 2;


### PR DESCRIPTION
I found a mistake in your implementation for the OP code 0xFX55 

As it is stated in the Cogwood reference:

>Fx55 - LD [I], Vx
>Store registers V0 through Vx in memory starting at location I.
>
>The interpreter copies the values of registers V0 through Vx into memory, starting at the address in I. 

http://devernay.free.fr/hacks/chip8/C8TECH10.HTM#0.1